### PR TITLE
Add support for external blosc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ option(APR_BUILD_STATIC_LIB "Builds shared library" ON)
 option(APR_BUILD_EXAMPLES "Build APR examples" OFF)
 option(APR_TESTS "Build APR tests" OFF)
 option(APR_PREFER_EXTERNAL_GTEST "When found, use the installed GTEST libs instead of included sources" OFF)
+option(APR_PREFER_EXTERNAL_BLOSC "When found, use the installed BLOSC libs instead of included sources" OFF)
 option(APR_BUILD_JAVA_WRAPPERS "Build APR JAVA wrappers" OFF)
 
 # Validation of options
@@ -20,6 +21,9 @@ if (NOT APR_BUILD_SHARED_LIB AND NOT APR_BUILD_STATIC_LIB)
     message(FATAL_ERROR "At least one target: APR_BUILD_SHARED_LIB or APR_BUILD_STATIC_LIB must be build!")
 endif()
 
+list(APPEND CMAKE_MODULE_PATH
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/)
 
 ###############################################################################
 # Generate configuration file
@@ -57,17 +61,26 @@ else()
 endif()
 include_directories(${HDF5_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS} ${TIFF_INCLUDE_DIR})
 
-# needed here for blosc library
-SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-# Configure and add submodule BLOSC
-set(BLOSC_IS_SUBPROJECT ON)
-set(BUILD_TESTS OFF CACHE BOOL "" FORCE)
-set(BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
-set(BUILD_SHARED OFF CACHE BOOL "" FORCE)
-set(BUILD_STATIC ON CACHE BOOL "" FORCE)
-add_subdirectory("external/c-blosc")
-include_directories(external/c-blosc/blosc)
+if(APR_PREFER_EXTERNAL_BLOSC)
+    find_package(BLOSC)
+endif()
+if(BLOSC_FOUND)
+    message(STATUS "APR: blosc found, using external blosc")
+    include_directories(${BLOSC_INCLUDE_DIR})
+else()
+    message(STATUS "APR: blosc not found, using internal blosc")
+    # needed here for blosc library
+    SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
+    # Configure and add submodule BLOSC
+    set(BLOSC_IS_SUBPROJECT ON)
+    set(BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+    set(BUILD_SHARED OFF CACHE BOOL "" FORCE)
+    set(BUILD_STATIC ON CACHE BOOL "" FORCE)
+    add_subdirectory("external/c-blosc")
+    include_directories(external/c-blosc/blosc)
+    set(BLOSC_LIBRARIES blosc_static)
+endif()
 
 # Add submodule GLM (include files only)
 include_directories("external/glm")
@@ -113,7 +126,9 @@ if(APR_BUILD_STATIC_LIB)
 
     # generate fat static library by adding dependencies
     include(cmake/AddStaticLibs.cmake)
-    addStaticLibs(${STATIC_TARGET_NAME} blosc_static)
+    if(NOT BLOSC_FOUND)
+        addStaticLibs(${STATIC_TARGET_NAME} blosc_static)
+    endif()
 endif()
 
 if(APR_BUILD_SHARED_LIB)
@@ -124,10 +139,15 @@ if(APR_BUILD_SHARED_LIB)
     set_target_properties(${SHARED_TARGET_NAME} PROPERTIES OUTPUT_NAME ${LIBRARY_NAME})
     set_target_properties(${SHARED_TARGET_NAME} PROPERTIES LIBRARY_OUTPUT_NAME ${LIBRARY_NAME})
     set_target_properties(${SHARED_TARGET_NAME} PROPERTIES ARCHIVE_OUTPUT_NAME ${LIBRARY_NAME})
-    add_dependencies(${SHARED_TARGET_NAME} blosc_static)
     set_property(TARGET ${SHARED_TARGET_NAME} PROPERTY VERSION ${APR_VERSION_STRING})
     set_property(TARGET ${SHARED_TARGET_NAME} PROPERTY SOVERSION ${APR_VERSION_MAJOR})
-    target_link_libraries(${SHARED_TARGET_NAME} PRIVATE ${HDF5_LIBRARIES} ${TIFF_LIBRARIES} -Wl,-force_load,$<TARGET_FILE:blosc_static> ${ZLIB_LIBRARIES})
+    target_link_libraries(${SHARED_TARGET_NAME} PRIVATE ${HDF5_LIBRARIES} ${TIFF_LIBRARIES})
+    if(BLOSC_FOUND)
+        target_link_libraries(${SHARED_TARGET_NAME} PRIVATE ${BLOSC_LIBRARIES} ${ZLIB_LIBRARIES})
+    else()
+        add_dependencies(${SHARED_TARGET_NAME} blosc_static)
+        target_link_libraries(${SHARED_TARGET_NAME} PRIVATE -Wl,-force_load,$<TARGET_FILE:blosc_static> ${ZLIB_LIBRARIES})
+    endif()
 endif()
 
 # choose one of the build libraries to be used later for tests and/or examples
@@ -233,5 +253,5 @@ if(APR_BUILD_JAVA_WRAPPERS)
     set(CMAKE_SWIG_FLAGS -package de.mpicbg.mosaic.apr -Wall)
     set_source_files_properties(libapr.i PROPERTIES CPLUSPLUS ON)
     swig_add_library(apr LANGUAGE java SOURCES libapr.i ${SOURCE_FILES})
-    swig_link_libraries(apr ${HDF5_LIBRARIES} blosc_static ${TIFF_LIBRARIES} ${ZLIB_LIBRARIES})
+    swig_link_libraries(apr ${HDF5_LIBRARIES} ${TIFF_LIBRARIES} ${BLOSC_LIBRARIES} ${ZLIB_LIBRARIES})
 endif(APR_BUILD_JAVA_WRAPPERS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ find_package(TIFF REQUIRED)
 # Handle OpenMP
 find_package(OpenMP)
 if(NOT OPENMP_FOUND OR DISABLE_OPENMP)
-    message(WARNING "OpenMP support not found with current compiler. While APR can compile like this, performance might not be optimal. Please see README.md for instructions.")
+    message(WARNING "OpenMP support not found or disabled with current compiler. While APR can compile like this, performance might not be optimal. Please see README.md for instructions.")
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_OPENMP ${OpenMP_C_FLAGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_OPENMP ${OpenMP_CXX_FLAGS}")
@@ -79,15 +79,17 @@ include_directories("external/glm")
 # If you ever want to compile with Intel's icc (or any other compiler) provide
 # compiler names/paths in cmake command like this:
 # CC="icc" CXX="icc" CXXFLAGS="-O3" cmake -DAPR_TESTS=1
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -pedantic ")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -pedantic")
 if(CMAKE_COMPILER_IS_GNUCC)
     set(CMAKE_CXX_FLAGS_RELEASE "-O4 -ffast-math")
     set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
-    set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -Bdynamic -ldl ")
-endif(CMAKE_COMPILER_IS_GNUCC)
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Bdynamic")
+    if(NOT WIN32)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -ldl")
+    endif()
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ffast-math")
-    set(CMAKE_CXX_FLAGS_DEBUG  "-O0 -g")
+    set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ message("Configuring for APR version: " ${APR_VERSION_STRING})
 # Find all required libraries
 ###############################################################################
 find_package(HDF5 REQUIRED)
+find_package(ZLIB REQUIRED)
 find_package(TIFF REQUIRED)
 
 # Handle OpenMP
@@ -54,7 +55,7 @@ else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_OPENMP ${OpenMP_C_FLAGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_OPENMP ${OpenMP_CXX_FLAGS}")
 endif()
-include_directories(${HDF5_INCLUDE_DIRS} ${TIFF_INCLUDE_DIR})
+include_directories(${HDF5_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS} ${TIFF_INCLUDE_DIR})
 
 # needed here for blosc library
 SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -124,7 +125,7 @@ if(APR_BUILD_SHARED_LIB)
     add_dependencies(${SHARED_TARGET_NAME} blosc_static)
     set_property(TARGET ${SHARED_TARGET_NAME} PROPERTY VERSION ${APR_VERSION_STRING})
     set_property(TARGET ${SHARED_TARGET_NAME} PROPERTY SOVERSION ${APR_VERSION_MAJOR})
-    target_link_libraries(${SHARED_TARGET_NAME} PRIVATE ${HDF5_LIBRARIES} ${TIFF_LIBRARIES} -Wl,-force_load,$<TARGET_FILE:blosc_static>)
+    target_link_libraries(${SHARED_TARGET_NAME} PRIVATE ${HDF5_LIBRARIES} ${TIFF_LIBRARIES} -Wl,-force_load,$<TARGET_FILE:blosc_static> ${ZLIB_LIBRARIES})
 endif()
 
 # choose one of the build libraries to be used later for tests and/or examples
@@ -230,5 +231,5 @@ if(APR_BUILD_JAVA_WRAPPERS)
     set(CMAKE_SWIG_FLAGS -package de.mpicbg.mosaic.apr -Wall)
     set_source_files_properties(libapr.i PROPERTIES CPLUSPLUS ON)
     swig_add_library(apr LANGUAGE java SOURCES libapr.i ${SOURCE_FILES})
-    swig_link_libraries(apr ${HDF5_LIBRARIES} blosc_static ${TIFF_LIBRARIES})
+    swig_link_libraries(apr ${HDF5_LIBRARIES} blosc_static ${TIFF_LIBRARIES} ${ZLIB_LIBRARIES})
 endif(APR_BUILD_JAVA_WRAPPERS)

--- a/cmake/Modules/FindBLOSC.cmake
+++ b/cmake/Modules/FindBLOSC.cmake
@@ -1,0 +1,64 @@
+#
+# FindBLOSC.cmake
+#
+#
+# The MIT License
+#
+# Copyright (c) 2016 MIT and Intel Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# Finds the Blosc library. This module defines:
+#   - BLOSC_INCLUDE_DIR, directory containing headers
+#   - BLOSC_LIBRARIES, the Blosc library path
+#   - BLOSC_FOUND, whether Blosc has been found
+
+# Find header files  
+if(BLOSC_SEARCH_HEADER_PATHS)
+  find_path( 
+      BLOSC_INCLUDE_DIR blosc.h 
+      PATHS ${BLOSC_SEARCH_HEADER_PATHS}   
+      NO_DEFAULT_PATH
+  )
+else()
+  find_path(BLOSC_INCLUDE_DIR blosc.h)
+endif()
+
+# Find library
+if(BLOSC_SEARCH_LIB_PATH)
+  find_library(
+      BLOSC_LIBRARIES NAMES blosc
+      PATHS ${BLOSC_SEARCH_LIB_PATH}$
+      NO_DEFAULT_PATH
+  )
+else()
+  find_library(BLOSC_LIBRARIES NAMES blosc)
+endif()
+
+if(BLOSC_INCLUDE_DIR AND BLOSC_LIBRARIES)
+  message(STATUS "Found Blosc: ${BLOSC_LIBRARIES}")
+  set(BLOSC_FOUND TRUE)
+else()
+  set(BLOSC_FOUND FALSE)
+endif()
+
+if(BLOSC_FIND_REQUIRED AND NOT BLOSC_FOUND)
+  message(FATAL_ERROR "Could not find the Blosc library.")
+endif()
+

--- a/src/misc/APRTimer.hpp
+++ b/src/misc/APRTimer.hpp
@@ -8,8 +8,9 @@
 #include <vector>
 #include <chrono>
 #include <iostream>
+#include <string>
 #ifdef HAVE_OPENMP
-	#include "omp.h"
+#include "omp.h"
 
 class APRTimer{
 //
@@ -53,7 +54,7 @@ public:
 
         if (verbose_flag){
             //output to terminal the result
-            std::cout <<  timing_names.back() << " took "
+            std::cout << timing_names.back() << " took "
                       << t2-t1
                       << " seconds\n";
         }

--- a/src/numerics/APRRaycaster.cpp
+++ b/src/numerics/APRRaycaster.cpp
@@ -1,5 +1,9 @@
 #include "../vis/RaytracedObject.h"
 #include "APRRaycaster.hpp"
+#include <cmath>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 // Implementation of glm related stuff. Main reason is to avoid necessity to have glm header files installed
 // to use libAPR.

--- a/src/vis/RaytracedObject.cpp
+++ b/src/vis/RaytracedObject.cpp
@@ -5,6 +5,7 @@
 #include "RaytracedObject.h"
 #include <glm/gtc/matrix_access.hpp>
 #include <iostream>
+#include <algorithm>
 
 RaytracedObject::RaytracedObject(glm::vec3 position, glm::fquat rotation) : Object(position, rotation) { this->position = position; this->rotation = rotation; }
 


### PR DESCRIPTION
This PR contains https://github.com/cheesema/LibAPR/pull/70 so please merge in order or merge only this PR.

Adding support for external c-blosc. If `-DAPR_PREFER_EXTERNAL_BLOSC=ON` is set, cmake will try to find c-blosc on the system. If c-blosc is *not* found, the internal c-blosc is automatically used as a fallback.